### PR TITLE
Remove text=auto from .gitattributes because it prevents development on linux

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,3 @@
-# Auto detect text files and perform LF normalization
-* text=auto
-
 # dont touch bash scripts so it doesnt mess up the shebang #!/bin/bash
 *.sh text eol=lf
 configure text eol=lf


### PR DESCRIPTION
With `text=auto` in the `.gitattributes` file, cloning the repository on a Linux box ends up doing line ending coversion on every text file.  The result is that the entire repository appears as "modified".

Removing the line lets git do its own automatic line-ending conversion process, which behaves more sanely.

I'd actually recomend removing the other lines as well, but they don't seem to be hurting anything at the moment.