### PR TITLE
Add script that resets docker build

### DIFF
--- a/scripts/docker-reset.sh
+++ b/scripts/docker-reset.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# vim: syntax=sh ts=4 sts=4 sw=4 expandtab
+
+PATH=/usr/local/bin:/usr/bin:/bin
+
+if [ ! -f docker/docker-compose.yml ]; then
+    echo "ERROR: Run this script from the root of the git repository."
+    exit 1
+fi
+
+cat <<EOF
+**********************************************************
+*** DANGER *** DANGER *** DANGER *** DANGER *** DANGER ***
+**********************************************************
+
+Executing this script will reset your local development
+build back to scratch.  It will:
+
+ * Shutdown your currently running development environment (if any)
+ * Delete the PostgreSQL data Docker volume
+ * Delete the media cache Docker volume
+ * Delete all of the built Docker container images
+
+You should only proceed if you are SURE you want to start
+over from scratch.
+
+EOF
+echo -n "Proceed? "
+read yn
+case $yn in
+    y*|Y*) : ;;
+    *)
+        echo "Aborting!"
+        exit 1
+        ;;
+esac
+
+echo "Shutting down the development stack"
+docker-compose -f docker/docker-compose.yml down
+
+echo "Removing data volumes"
+docker volume rm docker_media
+docker volume rm docker_postgres-data
+
+echo "Removing container images"
+for image in docker_beat docker_nginx docker_astrobin docker_celery; do
+    echo "-- $image"
+    docker image rm $image
+done
+    


### PR DESCRIPTION
While troubleshooting bringing up the stack, I found that lingering container data (namely, the PostgreSQL data volume) was tainting the startup process.  The PostgreSQL database didn't start up sanely the first time, and didn't set the username and password properly.  Subsequent attempts thus failed, because the username and password were not set.

I figured it would be handy to have a script that resets everything to zero, so starting the stack again works as if from scratch.