### PR TITLE
(images) Hide empty or zero values from acquisition details card

### DIFF
--- a/astrobin/templates/image/detail/image_card.html
+++ b/astrobin/templates/image/detail/image_card.html
@@ -51,14 +51,6 @@
 
                 <div class="acquisition">
                     <div class="acquisition-inner">
-                        {% for data in basic_data %}
-                            {% if request.user|can_view_technical_card_item:data %}
-                                <p>
-                                    <strong class="card-label">{{ data.0 }}:</strong> {{ data.1|safe|linebreaksbr }}
-                                </p>
-                            {% endif %}
-                        {% endfor %}
-
                         {% if image_type == 'deep_sky' %}
                             {% for data in deep_sky_data %}
                                 {% if request.user|can_view_technical_card_item:data %}
@@ -216,6 +208,10 @@
 
                 {% if request.user|can_view_full_technical_card or request.user == image.user %}
                     <hr />
+                {% endif %}
+
+                {% if resolution %}
+                    <p><strong class="card-label">{% trans "Resolution" %}:</strong> {{ resolution }}</p>
                 {% endif %}
 
                 {% if locations %}

--- a/astrobin/views/image.py
+++ b/astrobin/views/image.py
@@ -479,11 +479,6 @@ class ImageDetailView(ImageDetailViewBase):
         elif ssa:
             image_type = 'solar_system'
 
-        # Data that's common to both DS and SS images
-        basic_data = (
-            (_('Resolution'), '%dx%d' % (w, h) if (w and h) else None),
-        )
-
         profile = None
         if self.request.user.is_authenticated():
             profile = self.request.user.userprofile
@@ -708,7 +703,6 @@ class ImageDetailView(ImageDetailViewBase):
             'gear_list_has_paid_commercial': gear_list_has_paid_commercial,
             'image_type': image_type,
             'ssa': ssa,
-            'basic_data': basic_data,
             'deep_sky_data': deep_sky_data,
             'private_message_form': PrivateMessageForm(),
             'upload_revision_form': ImageRevisionUploadForm(),
@@ -721,6 +715,7 @@ class ImageDetailView(ImageDetailViewBase):
                 0] if image.subject_type else 0,
             'license_icon': static('astrobin/icons/%s' % licenses[image.license][1]),
             'license_title': licenses[image.license][2],
+            'resolution': '%dx%d' % (w, h) if (w and h) else None,
             'locations': locations,
             # Because of a regression introduced at
             # revision e1dad12babe5, now we have to

--- a/astrobin_apps_premium/templatetags/astrobin_apps_premium_tags.py
+++ b/astrobin_apps_premium/templatetags/astrobin_apps_premium_tags.py
@@ -146,7 +146,7 @@ def can_view_full_technical_card(user):
 
 @register.filter
 def can_view_technical_card_item(user, item):
-    if item[1] is None:
+    if not item[1]:
         return False
 
     if isinstance(item[1], QuerySet):


### PR DESCRIPTION
Additionally, move the Resolution entry down to the last secion.

Closes #872