### PR TITLE
(premium) Fix showing "inactive subscription" message on upload page

### DIFF
--- a/astrobin/templates/upload.html
+++ b/astrobin/templates/upload.html
@@ -21,7 +21,7 @@
             <h1>{% trans "Image upload" %}</h1>
         </div>
 
-        {% if premium_has_inact_sub %}
+        {% if premium_has_inactive_subscription %}
             <div class="row">
                 <div class="span10 offset1">
                     <div class="alert alert-warning">

--- a/astrobin/views/__init__.py
+++ b/astrobin/views/__init__.py
@@ -62,7 +62,8 @@ from astrobin_apps_platesolving.forms import PlateSolvingSettingsForm, PlateSolv
 from astrobin_apps_platesolving.models import PlateSolvingSettings, Solution, PlateSolvingAdvancedSettings
 from astrobin_apps_premium.templatetags.astrobin_apps_premium_tags import can_restore_from_trash, \
     can_perform_advanced_platesolving
-from astrobin_apps_premium.utils import premium_get_max_allowed_image_size, premium_get_max_allowed_revisions
+from astrobin_apps_premium.utils import premium_get_max_allowed_image_size, premium_get_max_allowed_revisions, \
+    premium_user_has_valid_subscription
 from astrobin_apps_users.services import UserService
 from toggleproperties.models import ToggleProperty
 
@@ -479,13 +480,15 @@ def image_upload(request):
 
     tmpl_premium_used_percent = premium_used_percent(request.user)
     tmpl_premium_progress_class = premium_progress_class(tmpl_premium_used_percent)
-    tmpl_premium_has_inact_sub = premium_user_has_subscription(request.user) and premium_user_has_invalid_subscription(
-        request.user)
+    tmpl_premium_has_inactive_subscription = \
+        premium_user_has_subscription(request.user) and \
+        premium_user_has_invalid_subscription(request.user) and \
+        not premium_user_has_valid_subscription(request.user)
 
     response_dict = {
         'premium_used_percent': tmpl_premium_used_percent,
         'premium_progress_class': tmpl_premium_progress_class,
-        'premium_has_inact_sub': tmpl_premium_has_inact_sub,
+        'premium_has_inactive_subscription': tmpl_premium_has_inactive_subscription,
     }
 
     if tmpl_premium_used_percent < 100:

--- a/astrobin_apps_premium/utils.py
+++ b/astrobin_apps_premium/utils.py
@@ -85,10 +85,22 @@ def premium_get_valid_usersubscription(user):
 
 
 def premium_get_invalid_usersubscription(user):
-    us = premium_get_usersubscription(user)
-    if not us.valid():
-        return us
-    return None
+    us = [obj for obj in UserSubscription.objects.filter(
+        user__username=user.username,
+        subscription__name__in=SUBSCRIPTION_NAMES,
+        active=True,
+    ) if not obj.valid()]
+
+    if len(us) == 0:
+        return None
+
+    if len(us) == 1:
+        return us[0]
+
+    sortedByName = sorted(us, cmp=_compareNames)
+    sortedByValidity = sorted(sortedByName, cmp=_compareValidity)
+
+    return sortedByName[0]
 
 
 def premium_used_percent(user):
@@ -141,7 +153,7 @@ def premium_user_has_valid_subscription(user):
 
 def premium_user_has_invalid_subscription(user):
     us = premium_get_invalid_usersubscription(user)
-    return us is not None
+    return not premium_user_has_valid_subscription(user) and us is not None
 
 
 def premium_get_max_allowed_image_size(user):


### PR DESCRIPTION
The message should not be shown if the user has another subscription that is valid.