### PR TITLE
(general) Do specify English (US) in language selector

### DIFF
--- a/astrobin/templatetags/tags.py
+++ b/astrobin/templatetags/tags.py
@@ -511,8 +511,8 @@ def get_other_languages():
 @register.simple_tag
 def get_language_name(language_code):
     languages = {
-        '': 'English',
-        'en': 'English',
+        '': 'English (US)',
+        'en': 'English (US)',
         'en-us': 'English (US)',
         'en-gb': 'English (GB)',
 
@@ -536,4 +536,4 @@ def get_language_name(language_code):
     try:
         return languages[language_code.lower()]
     except KeyError:
-        return 'English'
+        return 'English (US)'


### PR DESCRIPTION
The default English language uses US date format.