### PR TITLE
Migrate from master-slave language

### DIFF
--- a/astrobin/management/commands/merge_makes.py
+++ b/astrobin/management/commands/merge_makes.py
@@ -50,17 +50,17 @@ class Command(BaseCommand):
             if new_make == '':
                 new_make = item.make
 
-            masters = Gear.objects.filter(make = item.make)
-            for master in masters:
-                master.make = new_make
-                master.save()
+            mains = Gear.objects.filter(make = item.make)
+            for main in mains:
+                main.make = new_make
+                main.save()
                 number_merged += 1
 
             for i in shlex.split(to_merge):
-                slaves = Gear.objects.filter(make = matches[int(i)])
-                for slave in slaves:
-                    slave.make = new_make
-                    slave.save()
+                subordinates = Gear.objects.filter(make = matches[int(i)])
+                for subordinate in subordinates:
+                    subordinate.make = new_make
+                    subordinate.save()
                     number_merged += 1
 
             print "Merged %d makes." % number_merged

--- a/astrobin/migrations/0001_initial.py
+++ b/astrobin/migrations/0001_initial.py
@@ -489,13 +489,13 @@ class Migration(migrations.Migration):
         ),
         migrations.AddField(
             model_name='gearassistedmerge',
-            name='master',
-            field=models.ForeignKey(null=True, on_delete=django.db.models.deletion.CASCADE, related_name='assisted_master', to='astrobin.Gear'),
+            name='main',
+            field=models.ForeignKey(null=True, on_delete=django.db.models.deletion.CASCADE, related_name='assisted_main', to='astrobin.Gear'),
         ),
         migrations.AddField(
             model_name='gearassistedmerge',
-            name='slave',
-            field=models.ForeignKey(null=True, on_delete=django.db.models.deletion.CASCADE, related_name='assisted_slave', to='astrobin.Gear'),
+            name='subordinate',
+            field=models.ForeignKey(null=True, on_delete=django.db.models.deletion.CASCADE, related_name='assisted_subordinate', to='astrobin.Gear'),
         ),
         migrations.AddField(
             model_name='gear',
@@ -504,7 +504,7 @@ class Migration(migrations.Migration):
         ),
         migrations.AddField(
             model_name='gear',
-            name='master',
+            name='main',
             field=models.ForeignKey(editable=False, null=True, on_delete=django.db.models.deletion.CASCADE, to='astrobin.Gear'),
         ),
         migrations.AddField(

--- a/astrobin/tests/test_gear.py
+++ b/astrobin/tests/test_gear.py
@@ -118,12 +118,12 @@ class GearTest(TestCase):
         g1, created = Filter.objects.get_or_create(name = "1")
         g2, created = Filter.objects.get_or_create(name = "2")
 
-        # Assign slave to profile
+        # Assign subordinate to profile
         u = User.objects.create_user('test', 'test@test.com', 'password')
         u.userprofile.filters.add(g2)
         u.userprofile.save(keep_deleted=True)
 
-        # Assign slave to image
+        # Assign subordinate to image
         i, created  = Image.objects.get_or_create(user = u)
         i.filters.add(g2)
         i.save(keep_deleted=True)


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.