### PR TITLE
(general) Add staging gallery to dropdown and rename gallery to public gallery

### DIFF
--- a/astrobin/templates/base/user_links_entries.html
+++ b/astrobin/templates/base/user_links_entries.html
@@ -20,7 +20,14 @@
 <li>
     <a href="{% url 'user_page' request.user.username %}">
         <i class="icon-picture"></i>
-        {% trans "Gallery" %}
+        {% trans "Public Gallery" %}
+    </a>
+</li>
+
+<li>
+    <a href="{% url 'user_page' request.user.username %}?staging">
+        <i class="icon-lock"></i>
+        {% trans "Staging Gallery" %}
     </a>
 </li>
 

--- a/astrobin/templates/base/user_links_entries.html
+++ b/astrobin/templates/base/user_links_entries.html
@@ -27,7 +27,7 @@
 <li>
     <a href="{% url 'user_page' request.user.username %}?staging">
         <i class="icon-lock"></i>
-        {% trans "Staging Gallery" %}
+        {% trans "Staging Area" %}
     </a>
 </li>
 


### PR DESCRIPTION
The 'Gallery' link in the main user dropdown was renamed to 'Public Gallery', and a link to the user's staging gallery was added.