### PR TITLE
(uploader) Use shared directory for chunks

### DIFF
--- a/astrobin_apps_images/api/utils.py
+++ b/astrobin_apps_images/api/utils.py
@@ -174,7 +174,10 @@ def checksum_matches(checksum_algorithm, checksum, bytes):
 
 def get_or_create_temporary_file(image):
     if not get_cached_property("temporary-file-path", image):
-        fd, path = tempfile.mkstemp(prefix="tus-upload-")
+        directory = "/astrobin-temporary-files/files"
+        if not os.path.exists(directory):
+            os.makedirs(directory)
+        fd, path = tempfile.mkstemp(prefix="tus-upload-", dir=directory)
         os.close(fd)
         set_cached_property("temporary-file-path", image, path)
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -117,6 +117,7 @@ services:
     volumes:
       - media:/media
       - tmp:/tmp
+      - /astrobin-temporary-files:/astrobin-temporary-files
 
 
 volumes:


### PR DESCRIPTION
This ensures that the chunked upload works well in a multi-server environment.