### PR TITLE
(infra) Force Django < 2 and elasticsearch < 3

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,5 +4,19 @@
   ],
   "compatibility": {
     "python": "2.7"
-  }
+  },
+  "packageRules": [
+    {
+      "packageNames": [
+        "Django"
+      ],
+      "allowedVersions": "< 2"
+    },
+    {
+      "packageNames": [
+        "elasticsearch"
+      ],
+      "allowedVersions": "< 3"
+    }
+  ]
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -97,7 +97,7 @@ djangorestframework==3.6.3
 djangorestframework-camel-case==1.0.3
 docutils==0.16
 -e git+https://github.com/astrobin/easy-thumbnails.git@9b57a875ff3c99801f30e8ab25b7938a654934e4#egg=easy-thumbnails
-elasticsearch==7.9.1
+elasticsearch==2.4.1
 enum34==1.1.10
 fanstatic==1.1
 flickrapi==2.4.0


### PR DESCRIPTION
They will only be upgraded manually at some point.