### PR TITLE
(users) Forbid new accounts by case-insensitive existing username

### DIFF
--- a/astrobin/views/__init__.py
+++ b/astrobin/views/__init__.py
@@ -1066,9 +1066,14 @@ def me(request):
 @require_GET
 @silk_profile('User page')
 def user_page(request, username):
-    user = get_object_or_404(
-        User.objects.select_related('userprofile').prefetch_related('groups'),
-        username=username)
+    try:
+        user = UserService.get_case_insensitive(username)
+    except User.DoesNotExist:
+        raise Http404
+
+    if user.username != username:
+        return HttpResponseRedirect(reverse('user_page', args=(user.username,)))
+
     profile = user.userprofile
 
     if profile.deleted:

--- a/astrobin/views/registration.py
+++ b/astrobin/views/registration.py
@@ -4,6 +4,7 @@ from captcha.fields import ReCaptchaField
 from captcha.widgets import ReCaptchaV2Checkbox
 from django import forms
 from django.conf import settings
+from django.contrib.auth.models import User
 from django.utils.translation import ugettext_lazy as _
 from registration.backends.hmac.views import RegistrationView
 from registration.forms import (
@@ -44,6 +45,15 @@ class AstroBinRegistrationForm(RegistrationFormUniqueEmail,
             }
         )
     )
+
+    def clean(self):
+        username_value = self.cleaned_data.get(User.USERNAME_FIELD)
+        if username_value is not None and User.objects.filter(username__iexact=username_value).exists():
+            self.add_error(
+                User.USERNAME_FIELD,
+                _(u'Sorry, this username already exists with a different capitalization.'))
+
+        super(AstroBinRegistrationForm, self).clean()
 
 
 class AstroBinRegistrationView(RegistrationView):

--- a/astrobin_apps_users/services/user_service.py
+++ b/astrobin_apps_users/services/user_service.py
@@ -21,6 +21,26 @@ class UserService:
         self.user = user
 
     @staticmethod
+    def get_case_insensitive(username):
+        case_insensitive_matches = User.objects \
+            .select_related('userprofile') \
+            .prefetch_related('groups') \
+            .filter(username__iexact=username)
+
+        count = case_insensitive_matches.count()
+
+        if count == 0:
+            raise User.DoesNotExist
+
+        if count == 1:
+            return case_insensitive_matches.first()
+
+        return User.objects \
+            .select_related('userprofile') \
+            .prefetch_related('groups') \
+            .get(username__exact=username)
+
+    @staticmethod
     def corrupted_query():
         # type: () -> Q
         return Q(corrupted=True, is_final=True) | \

--- a/astrobin_apps_users/tests/test_user_service.py
+++ b/astrobin_apps_users/tests/test_user_service.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timedelta
 
+from django.contrib.auth.models import User
 from django.utils import timezone
 from mock import patch
 
@@ -12,6 +13,26 @@ from toggleproperties.models import ToggleProperty
 
 
 class TestUserService(TestCase):
+    def test_get_case_insensitive_none(self):
+        with self.assertRaises(User.DoesNotExist):
+            UserService.get_case_insensitive("foo")
+
+    def test_get_case_insensitive_one(self):
+        user = Generators.user(username="one")
+
+        self.assertEquals(user.username, UserService.get_case_insensitive("one").username)
+        self.assertEquals(user.username, UserService.get_case_insensitive("onE").username)
+
+    def test_get_case_insensitive_two(self):
+        user1 = Generators.user(username="one")
+        user2 = Generators.user(username="oNe")
+
+        self.assertEquals(user1.username, UserService.get_case_insensitive(user1.username).username)
+        self.assertEquals(user2.username, UserService.get_case_insensitive(user2.username).username)
+
+        with self.assertRaises(User.DoesNotExist):
+            UserService.get_case_insensitive("One")
+
     def test_get_all_images(self):
         user = Generators.user()
         image = Generators.image(user=user)


### PR DESCRIPTION
Additionally, when trying to access a user page with the wrong case,
try to match it in a case insensitive way if non ambiguous.

Closes #1571