### PR TITLE
(users) Get user's search query set by id instead of username

### DIFF
--- a/astrobin/views/__init__.py
+++ b/astrobin/views/__init__.py
@@ -1335,7 +1335,7 @@ def user_page(request, username):
     key = "User.%d.Stats.%s" % (user.pk, getattr(request, 'LANGUAGE_CODE', 'en'))
     data = cache.get(key)
     if data is None:
-        user_sqs = SearchQuerySet().models(User).filter(username=user.username)
+        user_sqs = SearchQuerySet().models(User).filter(django_id=user.pk)
         data = {}
 
         if user_sqs.count():


### PR DESCRIPTION
Searching by username is not an exact match, so it would find also users with a username
that is a superstring of this user's username, and then return wrong data.