### PR TITLE
(users) Show "images used" for Lite 2020 and "uploads used" for free and old Lite

### DIFF
--- a/astrobin/templates/user/profile/meta.html
+++ b/astrobin/templates/user/profile/meta.html
@@ -36,18 +36,27 @@
         </p>
         {% endif %}
 
-        <p>
-            {% trans "Images used" %}<br/>
-            <strong data-test="images-used">
-                {{requested_user.userprofile.premium_counter}} /
-                {% if requested_user|is_free %}{{PREMIUM_MAX_IMAGES_FREE_2020}}{% endif %}
-                {% if requested_user|is_lite %}{{PREMIUM_MAX_IMAGES_LITE}}{% endif %}
-                {% if requested_user|is_lite_2020 %}{{PREMIUM_MAX_IMAGES_LITE_2020}}{% endif %}
-                {% if requested_user|is_premium_2020 %}&infin;{% endif %}
-                {% if requested_user|is_premium %}&infin;{% endif %}
-                {% if requested_user|is_ultimate_2020 %}&infin;{% endif %}
-            </strong>
-        </p>
+        {% if requested_user|show_images_used %}
+            <p>
+                {% trans "Images used" %}<br />
+                <strong data-test="images-used">
+                    {# Lite 2020 is the only account with a limit on total images #}
+                    {{ requested_user.userprofile.premium_counter }} / {{ PREMIUM_MAX_IMAGES_LITE_2020 }}
+                </strong>
+            </p>
+        {% endif %}
+
+        {% if requested_user|show_uploads_used %}
+            <p>
+                {% trans "Images used" %}<br />
+                <strong data-test="uploads-used">
+                    {# Free and old Lite are the only accounts with a limit on upload count #}
+                    {{ requested_user.userprofile.premium_counter }} /
+                    {% if requested_user|is_free %}{{ PREMIUM_MAX_IMAGES_FREE_2020 }}{% endif %}
+                    {% if requested_user|is_lite %}{{ PREMIUM_MAX_IMAGES_LITE }}{% endif %}
+                </strong>
+            </p>
+        {% endif %}
 
         {% if requested_user|is_any_premium_subscription %}
         <p class="small"><em>{% trans "Thanks for your support!" %}</em></p>

--- a/astrobin/templatetags/tags.py
+++ b/astrobin/templatetags/tags.py
@@ -17,7 +17,7 @@ from astrobin.services.utils_service import UtilsService
 from astrobin.utils import get_image_resolution, decimal_to_hours_minutes_seconds, decimal_to_degrees_minutes_seconds
 from astrobin_apps_donations.templatetags.astrobin_apps_donations_tags import is_donor
 from astrobin_apps_premium.templatetags.astrobin_apps_premium_tags import is_premium_2020, is_premium, is_ultimate_2020, \
-    is_lite, is_any_ultimate, is_free
+    is_lite, is_any_ultimate, is_free, is_lite_2020
 from astrobin_apps_premium.utils import premium_get_valid_usersubscription
 from astrobin_apps_users.services import UserService
 
@@ -650,3 +650,13 @@ def show_click_and_drag_zoom(request, image):
 def show_10_year_anniversary_logo():
     # type: () -> bool
     return UtilsService.show_10_year_anniversary_logo()
+
+
+@register.filter
+def show_images_used(user):
+    return is_lite_2020(user)
+
+
+@register.filter
+def show_uploads_used(user):
+    return is_free(user) or is_lite(user)

--- a/astrobin/tests/test_user.py
+++ b/astrobin/tests/test_user.py
@@ -806,7 +806,7 @@ class UserTest(TestCase):
         self.assertContains(response, "<h4>Subscription</h4>", html=True)
         self.assertContains(response, "<strong data-test='subscription-type'>AstroBin Free</strong>", html=True)
         self.assertNotContains(response, "data-test=\"expiration-date\"")
-        self.assertContains(response, "<strong data-test='images-used'>0 / 123</strong>", html=True)
+        self.assertContains(response, "<strong data-test='uploads-used'>0 / 123</strong>", html=True)
 
         self.client.logout()
         image.delete()
@@ -831,7 +831,7 @@ class UserTest(TestCase):
             formats.date_format(us.expires, "SHORT_DATE_FORMAT") +
             "</strong>",
             html=True)
-        self.assertContains(response, "<strong data-test='images-used'>0 / 123</strong>", html=True)
+        self.assertContains(response, "<strong data-test='uploads-used'>0 / 123</strong>", html=True)
 
         self.client.logout()
         us.delete()
@@ -882,7 +882,6 @@ class UserTest(TestCase):
             formats.date_format(us.expires, "SHORT_DATE_FORMAT") +
             "</strong>",
             html=True)
-        self.assertContains(response, "<strong data-test='images-used'>0 / &infin;</strong>", html=True)
 
         self.client.logout()
         us.delete()
@@ -908,7 +907,6 @@ class UserTest(TestCase):
             formats.date_format(us.expires, "SHORT_DATE_FORMAT") +
             "</strong>",
             html=True)
-        self.assertContains(response, "<strong data-test='images-used'>0 / &infin;</strong>", html=True)
 
         self.client.logout()
         us.delete()
@@ -933,7 +931,6 @@ class UserTest(TestCase):
             formats.date_format(us.expires, "SHORT_DATE_FORMAT") +
             "</strong>",
             html=True)
-        self.assertContains(response, "<strong data-test='images-used'>0 / &infin;</strong>", html=True)
 
         self.client.logout()
         us.delete()


### PR DESCRIPTION
Don't show anything for accounts with infinite uploads.