### PR TITLE
Unify and improve unique_items

### DIFF
--- a/astrobin/management/commands/merge_makes.py
+++ b/astrobin/management/commands/merge_makes.py
@@ -6,24 +6,20 @@ from django.core.management.base import BaseCommand
 from django.db.models import Q
 
 from astrobin.models import Gear
+from astrobin.utils import unique_items
+
 
 class Command(BaseCommand):
     help = "Merges similar make names."
 
     def handle(self, *args, **options):
-        def unique_items(l):
-            found = []
-            for i in l:
-                if i not in found:
-                    found.append(i)
-            return found
 
         seen = []
         while True:
             number_merged = 0
 
-            queryset = Gear.objects.exclude(Q(make = None) | Q(make = '') | Q(make__in = seen))
-            all_makes = [x.make for x in Gear.objects.exclude(Q(make = None) | Q(make = ''))]
+            queryset = Gear.objects.exclude(Q(make=None) | Q(make='') | Q(make__in=seen))
+            all_makes = [x.make for x in Gear.objects.exclude(Q(make=None) | Q(make=''))]
 
             item = queryset[0]
             matches = unique_items(difflib.get_close_matches(item.make, all_makes))
@@ -50,7 +46,7 @@ class Command(BaseCommand):
             if new_make == '':
                 new_make = item.make
 
-            masters = Gear.objects.filter(make = item.make)
+            masters = Gear.objects.filter(make=item.make)
             for master in masters:
                 master.make = new_make
                 master.save()

--- a/astrobin/management/commands/rename_makes.py
+++ b/astrobin/management/commands/rename_makes.py
@@ -5,23 +5,18 @@ from django.core.management.base import BaseCommand
 from django.db.models import Q, Count
 
 from astrobin.models import Gear
+from astrobin.utils import unique_items
+
 
 class Command(BaseCommand):
     help = "Rename makes."
 
     def handle(self, *args, **options):
-        def unique_items(l):
-            found = []
-            for i in l:
-                if i not in found:
-                    found.append(i)
-            return found
-
         seen = []
         all_makes = sorted(unique_items(Gear.objects.exclude(
-            Q(make = None) |
-            Q(make = '') |
-            Q(make__in = seen)).values_list('make', flat = True)))
+            Q(make=None) |
+            Q(make='') |
+            Q(make__in=seen)).values_list('make', flat=True)))
 
         print "Total makes: %d." % len(all_makes)
 

--- a/astrobin/stats.py
+++ b/astrobin/stats.py
@@ -1,4 +1,5 @@
 from models import DeepSky_Acquisition, Image, UserProfile, Gear, User, Camera, Telescope
+from utils import unique_items
 
 from django.utils.translation import ugettext as _
 from django.db.models import Q
@@ -12,21 +13,13 @@ import unicodedata
 from collections import defaultdict
 import operator
 
-def unique_items(l):
-    found = []
-    for i in l:
-        if i not in found:
-            found.append(i)
-
-    return found
-
 
 def daterange(start, end):
     r = (end + timedelta(days=1) - start).days
     return [start + timedelta(days=i) for i in range(r)]
 
 
-def integration_hours(user, period = 'monthly', since = 0):
+def integration_hours(user, period='monthly', since=0):
     _map = {
         'yearly' : (_("Integration hours, yearly") , '%Y'),
         'monthly': (_("Integration hours, monthly"), '%Y-%m'),

--- a/astrobin/tests/test_utils.py
+++ b/astrobin/tests/test_utils.py
@@ -166,3 +166,9 @@ class UtilsTest(TestCase):
         accounts = utils.never_activated_accounts_to_be_deleted()
 
         self.assertEquals(2, accounts.count())
+
+    def test_unique_items(self):
+        list_with_duplicates = ['foo', 'bar', 'baz', 'foo', 2, 6, 10, 2]
+        expected_result = ['foo', 'bar', 'baz', 2, 6, 10]
+
+        self.assertEqual(sorted(expected_result), sorted(utils.unique_items(list_with_duplicates)))

--- a/astrobin/utils.py
+++ b/astrobin/utils.py
@@ -11,12 +11,11 @@ from django.db.models import Count
 from django.utils import timezone
 
 
-def unique_items(l):
-    found = []
-    for i in l:
-        if i not in found:
-            found.append(i)
-    return found
+def unique_items(list_with_possible_duplicates):
+    """
+    Given an initial list, returns a list but without duplicates
+    """
+    return list(set(list_with_possible_duplicates))
 
 
 ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
@@ -110,6 +109,7 @@ def get_client_country_code(request):
     except:
         return "UNKNOWN"
 
+
 def get_european_union_country_codes():
     return (
         'at',
@@ -140,6 +140,7 @@ def get_european_union_country_codes():
         'si',
         'sk',
     )
+
 
 def inactive_accounts():
     """Gets all the user profiles of users with at least one image, who haven't uploaded in over 2 months"""
@@ -258,7 +259,7 @@ def degrees_minutes_seconds_to_decimal_degrees(degrees, minutes, seconds, direct
     if degrees is None:
         degrees = 0
 
-    dd = float(degrees) + float(minutes) / 60 + float(seconds) / (60 * 60);
+    dd = float(degrees) + float(minutes) / 60 + float(seconds) / (60 * 60)
 
     if direction == 'E' or direction == 'N':
         dd *= -1


### PR DESCRIPTION
I noticed there were a couple of modules defining the same version of this util, this PR unifies them and implement a unique entrypoint for this functionality, additionally, the performance improved by 50%

```Python
>>> s="""
found = []
for i in [1,2,3,4,5,1,2,3,4,5,1,2,3,4,5,1,2,4,4,5,7,2,6,8,91,2,3,1,1,02,3,5,6,4,3,2,4,5,6,8,4,3]:
 if i not in found:
  found.append(i)
"""
>>> d="""list(set([1,2,3,4,5,1,2,3,4,5,1,2,3,4,5,1,2,4,4,5,7,2,6,8,91,2,3,1,1,02,3,5,6,4,3,2,4,5,6,8,4,3]))"""
>>> timeit.timeit(stmt=s, number=100000)
0.3887138366699219
>>> timeit.timeit(stmt=d, number=100000)
0.17331814765930176
```