### PR TITLE
(search) Add specific end time to update_index task

### DIFF
--- a/astrobin/tasks.py
+++ b/astrobin/tasks.py
@@ -194,11 +194,15 @@ def retrieve_primary_thumbnails(pk, options):
 @shared_task(time_limit=600)
 def update_index(model, age_in_minutes, batch_size):
     start = datetime.now() - timedelta(minutes=age_in_minutes)
+    end = datetime.now()
+
     call_command(
         'update_index',
         model,
         '-b %d'  % batch_size,
-        '--start=%s' % start.strftime("%Y-%m-%dT%H:%M:%S"))
+        '--start=%s' % start.strftime("%Y-%m-%dT%H:%M:%S"),
+        '--end=%s' % end.strftime("%Y-%m-%dT%H:%M:%S")
+    )
 
 
 @shared_task()


### PR DESCRIPTION
This way, if tasks are heavily delayed, they won't have to process too long a queue.