### PR TITLE
Add delay for the link form to load

### DIFF
--- a/cypress/integration/forums.js
+++ b/cypress/integration/forums.js
@@ -103,9 +103,11 @@ describe("Forums", () => {
 
     it("should insert link", () => { 
         cy.get(".cke_button__simplelink").click();
+        cy.wait(1500);
         cy.get(".cke_dialog_ui_input_text input").first().type("https://astrobin.com");
         cy.get(".cke_dialog_ui_input_text input").last().type("Astrobin");
         cy.get(".cke_dialog_ui_button_ok").click();
+        cy.wait(1500);
         cy.get("#cke_id_body .cke_wysiwyg_div a").should("contain", "Astrobin");
     });
 });


### PR DESCRIPTION
Adding a 1500ms delay prevents Cypress from attempting to type in the form before it loads.