### PR TITLE
Fix tooltip getting clipped by avatar

### DIFF
--- a/astrobin/static/astrobin/scss/astrobin.scss
+++ b/astrobin/static/astrobin/scss/astrobin.scss
@@ -3016,7 +3016,6 @@ ul.astrobin-users {
   .avatar {
     width: 194px;
     height: 194px;
-    overflow: hidden;
 
     &:hover .icon.edit {
       position: absolute;


### PR DESCRIPTION
Hi everyone! I should say that I highly appreciate the effort put into astrobin. I've been loosely using it from time to time.

I've just created an issue (#1861) recently and this PR is my attempt for solving the issue.

First of all, I didn't set up the local development environment, as it seems pretty time-consuming and my fix is quite a small, cosmetic one. But I tried my proposed change in devtools in astrobin.com and it seems to be working without affecting anything else.

I think, in the past `overflow: hidden` might have been added for the purpose of clipping the semi-transparent profile-details layer in the avatar container. But currently that part is not affected by this change.

And here's how it looks after my change:

(hovered on unfollow button)
![image](https://user-images.githubusercontent.com/5516876/105072549-9a914680-5a8e-11eb-8460-6727784bbb27.png)
