### PR TITLE
Fix unique items on nested lists

### DIFF
--- a/astrobin/tests/test_utils.py
+++ b/astrobin/tests/test_utils.py
@@ -172,3 +172,10 @@ class UtilsTest(TestCase):
         expected_result = ['foo', 'bar', 'baz', 2, 6, 10]
 
         self.assertEqual(sorted(expected_result), sorted(utils.unique_items(list_with_duplicates)))
+
+    def test_unique_items_list_not_flat(self):
+        list_with_duplicates = ['foo', 'bar', 'baz', 'foo',
+                                2, ['b', 'c', 'a'], 6, 10, 2, ['b', 'c', 'a']]
+        expected_result = ['foo', 'bar', 'baz', 2, ['b', 'c', 'a'], 6, 10]
+
+        self.assertEqual(expected_result, utils.unique_items(list_with_duplicates))

--- a/astrobin/utils.py
+++ b/astrobin/utils.py
@@ -15,7 +15,15 @@ def unique_items(list_with_possible_duplicates):
     """
     Given an initial list, returns a list but without duplicates
     """
-    return list(set(list_with_possible_duplicates))
+    try:
+        return list(set(list_with_possible_duplicates))
+    except TypeError:
+        # We have a list which is not flat, use the old way to remove duplicates
+        found = []
+        for i in list_with_possible_duplicates:
+            if i not in found:
+                found.append(i)
+        return found
 
 
 ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"


### PR DESCRIPTION
This should fix the issue with unique items when used on nested lists, sorted can't be used anyway on nested lists if those are made by different types