### PR TITLE
(general) Fix max age of language cookie

### DIFF
--- a/astrobin/settings/components/languages.py
+++ b/astrobin/settings/components/languages.py
@@ -2,6 +2,7 @@
 # http://www.i18nguy.com/unicode/language-identifiers.html
 LANGUAGE_CODE = 'en-us'
 LANGUAGE_COOKIE_NAME = 'astrobin_lang'
+LANGUAGE_COOKIE_AGE=60*60*24*365*10
 
 gettext = lambda s: s
 LANGUAGES = (

--- a/astrobin/views/__init__.py
+++ b/astrobin/views/__init__.py
@@ -2089,7 +2089,10 @@ def user_profile_save_preferences(request):
             if hasattr(request, 'session'):
                 request.session['django_language'] = lang
 
-            response.set_cookie(settings.LANGUAGE_COOKIE_NAME, lang)
+            response.set_cookie(
+                settings.LANGUAGE_COOKIE_NAME, lang,
+                max_age=settings.LANGUAGE_COOKIE_AGE
+            )
             activate(lang)
     else:
         return render(request, "user/profile/edit/preferences.html", response_dict)
@@ -2380,7 +2383,10 @@ def set_language(request, language_code):
         if hasattr(request, 'session'):
             request.session['django_language'] = language_code
 
-        response.set_cookie(settings.LANGUAGE_COOKIE_NAME, language_code)
+        response.set_cookie(
+            settings.LANGUAGE_COOKIE_NAME, language_code,
+            max_age=settings.LANGUAGE_COOKIE_AGE
+        )
         activate(language_code)
 
         if request.user.is_authenticated():


### PR DESCRIPTION
Before this patch, it was set to 0, so not actually preserved, and you'd get the browser's default
language after a browser restart.