### PR TITLE
(images) Fix keeping default license after upload from beta uploader (again)

### DIFF
--- a/astrobin_apps_images/api/serializers/image_upload_serializer.py
+++ b/astrobin_apps_images/api/serializers/image_upload_serializer.py
@@ -27,4 +27,5 @@ class ImageUploadSerializer(serializers.ModelSerializer):
             'w',
             'h',
             'uploader_in_progress',
+            'license'
         )


### PR DESCRIPTION
It got broken again when renaming the ImageSerializer.