### PR TITLE
fix BASE_URL to reflect default value

### DIFF
--- a/docker/astrobin.env
+++ b/docker/astrobin.env
@@ -63,7 +63,7 @@
 
 # This is your website's URL. It's used in notification emails and the API. For
 # development purposes, you can just set it to localhost.
-# BASE_URL=localhost # default: http://localhost
+# BASE_URL=http://localhost:8083 # default: http://localhost:8083
 
 # This is just like the above setting, but it's used if you have an alternative
 # short domain address. It's used when sharing files.


### PR DESCRIPTION
the BASE_URL of localhost does not correctly reflect the actual BASE_URL of localhost:8083