### PR TITLE
(infra) Don't invalidate cached thumbnails and solution annotations: just let them expire

### DIFF
--- a/astrobin/models.py
+++ b/astrobin/models.py
@@ -1752,7 +1752,6 @@ class Image(HasSolutionMixin, SafeDeleteModel):
         return static('astrobin/images/placeholder-gallery.jpg')
 
     def thumbnail_invalidate_real(self, field, revision_label, delete=True):
-        from astrobin.tasks import invalidate_cdn_caches
         from astrobin_apps_images.models import ThumbnailGroup
 
         for alias, thumbnail_settings in settings.THUMBNAIL_ALIASES[''].items():
@@ -1764,8 +1763,6 @@ class Image(HasSolutionMixin, SafeDeleteModel):
         try:
             thumbnail_group = self.thumbnails.get(revision=revision_label)  # type: ThumbnailGroup
             all_urls: List[str] = [x for x in thumbnail_group.get_all_urls() if x and x.startswith('http')]
-
-            invalidate_cdn_caches.delay(all_urls)
 
             if settings.AWS_S3_ENABLED:
                 for url in all_urls:

--- a/astrobin_apps_platesolving/models/solution.py
+++ b/astrobin_apps_platesolving/models/solution.py
@@ -285,16 +285,8 @@ class Solution(models.Model):
         self.status = Solver.MISSING
         self.submission_id = None
 
-        invalidate_urls = []
-
-        if self.image_file and self.image_file.url:
-            invalidate_urls.append(self.image_file.url)
-
         self.image_file.delete(save=False)
         self.image_file = None
-
-        if self.skyplot_zoom1 and self.skyplot_zoom1.url:
-            invalidate_urls.append(self.skyplot_zoom1.url)
 
         self.skyplot_zoom1.delete()
         self.skyplot_zoom1 = None
@@ -306,10 +298,6 @@ class Solution(models.Model):
         self.orientation = None
         self.radius = None
         self.annotations = None
-
-        if len(invalidate_urls) > 0:
-            from astrobin.tasks import invalidate_cdn_caches
-            invalidate_cdn_caches.delay(invalidate_urls)
 
     def _do_clear_advanced(self):
         if self.status > Solver.SUCCESS:


### PR DESCRIPTION
Invalidating is quite expensive, so we only invalidate the original uploads and let the thumbnails expires after 30 days.